### PR TITLE
Fix File Renaming

### DIFF
--- a/src/utils/fileManagement.js
+++ b/src/utils/fileManagement.js
@@ -105,7 +105,10 @@ export async function fileDuplicate(e, chatId, fileName, fileId, fileType){
 
 export async function fileRename(e, chatId, fileName, fileId, fileType){
     let id = chatIdCheck(chatId)
-    const newFileName = prompt("Enter new file name");
+    const newFileName = prompt("Enter new file name", fileName);
+    if (newFileName === null || newFileName === ""){
+        return
+    }
     await fetch(`${url}/files/rename/${id}/${fileName}/${fileId}/${fileType}`, {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
When canceling a file name prompt, it no longer sets the file name to `null`.
The current file name is now the default value of the prompt.

